### PR TITLE
fix: 修复更改layout后，布局未发生变更的BUG

### DIFF
--- a/src/Graphin.ts
+++ b/src/Graphin.ts
@@ -150,7 +150,7 @@ export const Graphin: DefineComponent<GraphinProps> = defineComponent({
       options: { ...otherOptions } as GraphOptions,
     })
     // self.props不会同步变化
-    watch(() => props, (newProps) => self.props = {...newProps})
+    watch(() => props, (newProps) => self.props = {...newProps}, { deep: true })
 
     /** Graph的DOM */
     const graphDOM = ref<HTMLDivElement | null>(null);
@@ -382,7 +382,7 @@ export const Graphin: DefineComponent<GraphinProps> = defineComponent({
         /** 数据需要从画布中来 */
         // @ts-ignore
         self.data = self.layout.getDataFromGraph()
-        self.layout.changeLayout(layout);
+        self.layout.changeLayout();
         self.graph.emit('graphin:layoutchange', { prevLayout: prevLayout, layout });
       },
     );


### PR DESCRIPTION
将props的更新设置为深度监听，
内部layoutController在更新布局参数时，才能获取到正确的最新布局参数